### PR TITLE
Increasing cov of network errors

### DIFF
--- a/Tests/StravaAPIClientTests/StravaAPIClientMockTests.swift
+++ b/Tests/StravaAPIClientTests/StravaAPIClientMockTests.swift
@@ -62,13 +62,39 @@ class StravaAPIClientMockTests: XCTestCase {
         self.removeStub(stub)
     }
 
-    func testMockCurrentLoggedInAthleteError() {
+    /// Extensive error test to cover the .underlyingError case
+    func testMockCurrentLoggedInAthleteErrorUnderlyingNSError() {
 
-        let errorStub = self.mockServerError(path: "\(Constants.apiPrefix)/athlete/athlete")
+        let errorStub = self.mockServerError(path: "\(Constants.apiPrefix)/athlete")
         let expectation = XCTestExpectation(description: "requestCurrentAthlete")
         self.client.requestCurrentAthlete { result in
 
-            if case .failure = result {
+            if case let .failure(err) = result,
+                case let .underlyingError(someNSError as NSError) = err,
+                someNSError.domain == "D",
+                someNSError.code == 123456 {
+
+                expectation.fulfill()
+
+            } else {
+
+                XCTFail()
+            }
+        }
+
+        self.wait(for: [expectation], timeout: 2.0)
+        self.removeStub(errorStub)
+    }
+
+    /// Extensive error test to cover the .emptyData case
+    func testMockCurrentLoggedInAthleteErrorEmptyData() {
+
+        let errorStub = self.mockServerEmptyData(path: "\(Constants.apiPrefix)/athlete")
+        let expectation = XCTestExpectation(description: "requestCurrentAthlete")
+        self.client.requestCurrentAthlete { result in
+
+            if case let .failure(err) = result,
+                case .emptyData = err {
 
                 expectation.fulfill()
 

--- a/Tests/StravaAPIClientTests/XCTestCase+Load.swift
+++ b/Tests/StravaAPIClientTests/XCTestCase+Load.swift
@@ -21,8 +21,15 @@ extension XCTestCase {
     }
 
     @discardableResult
-    func mockServerError(path: String, verb: HTTPMethod = .get) -> Stub {
+    func mockServerEmptyData(path: String, verb: HTTPMethod = .get) -> Stub {
 
         return stub(http(verb, uri: path), http(500))
     }
+
+    @discardableResult
+    func mockServerError(path: String, verb: HTTPMethod = .get) -> Stub {
+
+        return stub(http(verb, uri: path), failure(NSError(domain: "D", code: 123456, userInfo: nil)))
+    }
+
 }


### PR DESCRIPTION
## What?

* Testing `DangerFile` on a real PR
* `mockServerEmptyData` and `mockServerError` now can cover both network error scenarios - hope to increase cov and cover all error scenarios with this change