### PR TITLE
Improving error handling on Networking

### DIFF
--- a/Sources/Extensions/Data.swift
+++ b/Sources/Extensions/Data.swift
@@ -1,0 +1,28 @@
+//
+//  Data.swift
+//  StravaAPIClient
+//
+//  Created by Carlos Santos on 06/03/2018.
+//  Copyright © 2018 crsantos.info. All rights reserved.
+//
+
+import Foundation
+
+extension Optional where Wrapped == Data {
+
+    enum DataResult {
+
+        case data(Data)
+        case empty
+    }
+
+    var unwrapped: DataResult {
+
+        if let data = self,
+            data.isEmpty == false {
+
+            return .data(data)
+        }
+        return .empty
+    }
+}

--- a/Sources/Extensions/HTTPURLResponse.swift
+++ b/Sources/Extensions/HTTPURLResponse.swift
@@ -1,0 +1,17 @@
+//
+//  HTTPURLResponse.swift
+//  StravaAPIClient
+//
+//  Created by Carlos Santos on 05/03/2018.
+//  Copyright © 2018 crsantos.info. All rights reserved.
+//
+
+import Foundation
+
+extension HTTPURLResponse {
+
+    var hasAcceptableStatusCode: Bool {
+
+        return (200...299 ~= self.statusCode)
+    }
+}

--- a/Sources/Models/APIErrorModel.swift
+++ b/Sources/Models/APIErrorModel.swift
@@ -1,0 +1,35 @@
+//
+//  APIError.swift
+//  StravaAPIClient
+//
+//  Created by Carlos Santos on 03/03/2018.
+//  Copyright © 2018 crsantos.info. All rights reserved.
+//
+
+import Foundation
+
+public struct APIErrorModel: Codable {
+
+    let message: String
+    let errors: [APIErrorElement]
+
+    enum CodingKeys: String, CodingKey {
+
+        case message
+        case errors
+    }
+}
+
+public struct APIErrorElement: Codable {
+
+    let resource: String
+    let field: String
+    let code: String
+
+    enum CodingKeys: String, CodingKey {
+
+        case resource
+        case field
+        case code
+    }
+}

--- a/Sources/Network/Errors/Errors.swift
+++ b/Sources/Network/Errors/Errors.swift
@@ -1,0 +1,101 @@
+//
+//  Errors.swift
+//  StravaAPIClient
+//
+//  Created by Carlos Santos on 05/03/2018.
+//  Copyright © 2018 crsantos.info. All rights reserved.
+//
+
+import Foundation
+
+fileprivate enum HeaderConstants {
+
+    static let rateLimitLimitKey = "X-RateLimit-Limit"
+    static let rateLimitUsageKey = "X-RateLimit-Usage"
+}
+
+public enum NetworkingError: Error {
+
+    case generic
+    case emptyData
+    case underlyingError(Error)
+    case parsingError(ParseError)
+    case apiError(APIHTTPError, APIErrorModel)
+}
+
+public enum ParseError: Error {
+
+    case emptyResponse
+    case decode(Error) // TODO: try to put it as DecodingError -> catching all of them on Networking
+}
+
+public struct RateLimit {
+
+    let shortTerm: Int
+    let longTerm: Int
+}
+
+public enum APIHTTPError: Error {
+
+    case notFound
+    case unauthorized
+    case rateLimitingExceeded(RateLimit, RateLimit)
+    case forbidden
+    case unknown
+
+    static func fromResponse(_ response: HTTPURLResponse) -> APIHTTPError {
+
+        let httpAPIError: APIHTTPError
+
+        switch response.statusCode {
+
+        case 401:
+
+            httpAPIError = .unauthorized
+
+        case 404:
+
+            httpAPIError = .notFound
+
+        case 403:
+
+            if let rateLimitLimit = response.allHeaderFields[HeaderConstants.rateLimitLimitKey] as? String,
+                let rateLimitUsage = response.allHeaderFields[HeaderConstants.rateLimitUsageKey] as? String {
+
+                let usageTuple = rateLimitUsage.split(separator: ",")
+                let limitTuple = rateLimitLimit.split(separator: ",")
+
+                if limitTuple.count == 2,
+                    usageTuple.count == limitTuple.count,
+                    let shortUsage = usageTuple.first,
+                    let longUsage = usageTuple.last,
+                    let shortLimit = limitTuple.first,
+                    let longLimit = limitTuple.last,
+                    let shortTermUsage = Int(String(describing: shortUsage)),
+                    let longTermUsage = Int(String(describing: longUsage)),
+                    let shortTermLimit = Int(String(describing: shortLimit)),
+                    let longTermLimit = Int(String(describing: longLimit)) {
+
+                    httpAPIError = .rateLimitingExceeded(
+                        RateLimit(shortTerm: shortTermLimit, longTerm: longTermLimit),
+                        RateLimit(shortTerm: shortTermUsage, longTerm: longTermUsage)
+                    )
+
+                } else {
+
+                    httpAPIError = .unknown // fallsback to unknown if it can't find the headers
+                }
+
+            } else {
+
+                httpAPIError = .forbidden
+            }
+
+        default:
+
+            httpAPIError = .unknown
+        }
+
+        return httpAPIError
+    }
+}

--- a/Sources/Network/Networking.swift
+++ b/Sources/Network/Networking.swift
@@ -50,8 +50,7 @@ fileprivate extension Networking {
 
         if let response = response as? HTTPURLResponse,
             response.hasAcceptableStatusCode == false,
-            let data = data,
-            data.isEmpty == false {
+            case let .data(data) = data.unwrapped {
 
             self.handleErrorData(data, response: response, completion: completion)
             return

--- a/Sources/Network/Networking.swift
+++ b/Sources/Network/Networking.swift
@@ -82,14 +82,14 @@ fileprivate extension Networking {
 
     func handleErrorData<T: Codable>(_ data: Data, response: HTTPURLResponse, completion: APICompletion<T>) {
 
-        self.parseError(data, completion: { result in
+        self.parseError(data) { result in
 
             if case let .success(apiErrorModel) = result {
 
                 let httpAPIError = APIHTTPError.fromResponse(response)
                 completion(.failure(.apiError(httpAPIError, apiErrorModel)))
             }
-        })
+        }
     }
 
     func parse<T: Codable>(_ data: Data, completion: APICompletion<T>) {

--- a/StravaAPIClient.xcodeproj/project.pbxproj
+++ b/StravaAPIClient.xcodeproj/project.pbxproj
@@ -79,6 +79,10 @@
 		1F5F5730204DFC1800EA471F /* current_athlete_200_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F572F204DFC1800EA471F /* current_athlete_200_invalid.json */; };
 		1F5F5731204DFC1800EA471F /* current_athlete_200_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F572F204DFC1800EA471F /* current_athlete_200_invalid.json */; };
 		1F5F5732204DFC1800EA471F /* current_athlete_200_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F572F204DFC1800EA471F /* current_athlete_200_invalid.json */; };
+		1F5F5734204E8AE100EA471F /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5F5733204E8AE100EA471F /* Data.swift */; };
+		1F5F5735204E8AE100EA471F /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5F5733204E8AE100EA471F /* Data.swift */; };
+		1F5F5736204E8AE100EA471F /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5F5733204E8AE100EA471F /* Data.swift */; };
+		1F5F5737204E8AE100EA471F /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5F5733204E8AE100EA471F /* Data.swift */; };
 		1FB22C08204AA29C00727745 /* APIErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB22C07204AA29C00727745 /* APIErrorModel.swift */; };
 		1FB22C09204AA29C00727745 /* APIErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB22C07204AA29C00727745 /* APIErrorModel.swift */; };
 		1FB22C0A204AA29C00727745 /* APIErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB22C07204AA29C00727745 /* APIErrorModel.swift */; };
@@ -192,6 +196,7 @@
 		1F5F5726204DF6CA00EA471F /* HTTPURLResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPURLResponse.swift; sourceTree = "<group>"; };
 		1F5F572B204DF92100EA471F /* error_unauthorized_401.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = error_unauthorized_401.json; sourceTree = "<group>"; };
 		1F5F572F204DFC1800EA471F /* current_athlete_200_invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = current_athlete_200_invalid.json; sourceTree = "<group>"; };
+		1F5F5733204E8AE100EA471F /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		1FB22C07204AA29C00727745 /* APIErrorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIErrorModel.swift; sourceTree = "<group>"; };
 		1FF53F5B1FF531B200E12D4F /* swiftlint.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = swiftlint.sh; path = scripts/swiftlint.sh; sourceTree = "<group>"; };
 		1FF53F5C1FF531BB00E12D4F /* Gemfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile; sourceTree = "<group>"; };
@@ -377,6 +382,7 @@
 			isa = PBXGroup;
 			children = (
 				1F5F5726204DF6CA00EA471F /* HTTPURLResponse.swift */,
+				1F5F5733204E8AE100EA471F /* Data.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1184,6 +1190,7 @@
 				1FF53F901FF5A78700E12D4F /* RequestSerializer.swift in Sources */,
 				1F52BD302038A61900F00ADC /* HighlightedKudoser.swift in Sources */,
 				1FF53F861FF54A0E00E12D4F /* StravaAPIRouter.swift in Sources */,
+				1F5F5734204E8AE100EA471F /* Data.swift in Sources */,
 				1F5F5722204DF00800EA471F /* Errors.swift in Sources */,
 				1FF53F6B1FF5329D00E12D4F /* Bike.swift in Sources */,
 				1FB22C08204AA29C00727745 /* APIErrorModel.swift in Sources */,
@@ -1223,6 +1230,7 @@
 				1FF53F921FF5A78700E12D4F /* RequestSerializer.swift in Sources */,
 				1F52BD322038A61900F00ADC /* HighlightedKudoser.swift in Sources */,
 				1FF53F881FF54A0E00E12D4F /* StravaAPIRouter.swift in Sources */,
+				1F5F5736204E8AE100EA471F /* Data.swift in Sources */,
 				1F5F5724204DF00800EA471F /* Errors.swift in Sources */,
 				1FF53F6D1FF5329D00E12D4F /* Bike.swift in Sources */,
 				1FB22C0A204AA29C00727745 /* APIErrorModel.swift in Sources */,
@@ -1252,6 +1260,7 @@
 				1FF53F931FF5A78700E12D4F /* RequestSerializer.swift in Sources */,
 				1F52BD332038A61900F00ADC /* HighlightedKudoser.swift in Sources */,
 				1FF53F891FF54A0E00E12D4F /* StravaAPIRouter.swift in Sources */,
+				1F5F5737204E8AE100EA471F /* Data.swift in Sources */,
 				1F5F5725204DF00800EA471F /* Errors.swift in Sources */,
 				1FF53F6E1FF5329D00E12D4F /* Bike.swift in Sources */,
 				1FB22C0B204AA29C00727745 /* APIErrorModel.swift in Sources */,
@@ -1281,6 +1290,7 @@
 				1FF53F911FF5A78700E12D4F /* RequestSerializer.swift in Sources */,
 				1F52BD312038A61900F00ADC /* HighlightedKudoser.swift in Sources */,
 				1FF53F871FF54A0E00E12D4F /* StravaAPIRouter.swift in Sources */,
+				1F5F5735204E8AE100EA471F /* Data.swift in Sources */,
 				1F5F5723204DF00800EA471F /* Errors.swift in Sources */,
 				1FF53F6C1FF5329D00E12D4F /* Bike.swift in Sources */,
 				1FB22C09204AA29C00727745 /* APIErrorModel.swift in Sources */,

--- a/StravaAPIClient.xcodeproj/project.pbxproj
+++ b/StravaAPIClient.xcodeproj/project.pbxproj
@@ -59,6 +59,30 @@
 		1F5CBB3E203D643700625DBF /* AthleteStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5CBB3C203D643700625DBF /* AthleteStats.swift */; };
 		1F5CBB3F203D643700625DBF /* AthleteStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5CBB3C203D643700625DBF /* AthleteStats.swift */; };
 		1F5CBB40203D643700625DBF /* AthleteStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5CBB3C203D643700625DBF /* AthleteStats.swift */; };
+		1F5F5719204DD15700EA471F /* error_notfound_404.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F5718204DD15700EA471F /* error_notfound_404.json */; };
+		1F5F571A204DD15700EA471F /* error_notfound_404.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F5718204DD15700EA471F /* error_notfound_404.json */; };
+		1F5F571B204DD15700EA471F /* error_notfound_404.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F5718204DD15700EA471F /* error_notfound_404.json */; };
+		1F5F571D204DEC4000EA471F /* error_rate_limit_403.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F571C204DEC4000EA471F /* error_rate_limit_403.json */; };
+		1F5F571E204DEC4000EA471F /* error_rate_limit_403.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F571C204DEC4000EA471F /* error_rate_limit_403.json */; };
+		1F5F571F204DEC4000EA471F /* error_rate_limit_403.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F571C204DEC4000EA471F /* error_rate_limit_403.json */; };
+		1F5F5722204DF00800EA471F /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5F5721204DF00800EA471F /* Errors.swift */; };
+		1F5F5723204DF00800EA471F /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5F5721204DF00800EA471F /* Errors.swift */; };
+		1F5F5724204DF00800EA471F /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5F5721204DF00800EA471F /* Errors.swift */; };
+		1F5F5725204DF00800EA471F /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5F5721204DF00800EA471F /* Errors.swift */; };
+		1F5F5727204DF6CA00EA471F /* HTTPURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5F5726204DF6CA00EA471F /* HTTPURLResponse.swift */; };
+		1F5F5728204DF6CA00EA471F /* HTTPURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5F5726204DF6CA00EA471F /* HTTPURLResponse.swift */; };
+		1F5F5729204DF6CA00EA471F /* HTTPURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5F5726204DF6CA00EA471F /* HTTPURLResponse.swift */; };
+		1F5F572A204DF6CA00EA471F /* HTTPURLResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5F5726204DF6CA00EA471F /* HTTPURLResponse.swift */; };
+		1F5F572C204DF92100EA471F /* error_unauthorized_401.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F572B204DF92100EA471F /* error_unauthorized_401.json */; };
+		1F5F572D204DF92100EA471F /* error_unauthorized_401.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F572B204DF92100EA471F /* error_unauthorized_401.json */; };
+		1F5F572E204DF92100EA471F /* error_unauthorized_401.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F572B204DF92100EA471F /* error_unauthorized_401.json */; };
+		1F5F5730204DFC1800EA471F /* current_athlete_200_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F572F204DFC1800EA471F /* current_athlete_200_invalid.json */; };
+		1F5F5731204DFC1800EA471F /* current_athlete_200_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F572F204DFC1800EA471F /* current_athlete_200_invalid.json */; };
+		1F5F5732204DFC1800EA471F /* current_athlete_200_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F5F572F204DFC1800EA471F /* current_athlete_200_invalid.json */; };
+		1FB22C08204AA29C00727745 /* APIErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB22C07204AA29C00727745 /* APIErrorModel.swift */; };
+		1FB22C09204AA29C00727745 /* APIErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB22C07204AA29C00727745 /* APIErrorModel.swift */; };
+		1FB22C0A204AA29C00727745 /* APIErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB22C07204AA29C00727745 /* APIErrorModel.swift */; };
+		1FB22C0B204AA29C00727745 /* APIErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB22C07204AA29C00727745 /* APIErrorModel.swift */; };
 		1FF53F671FF5329D00E12D4F /* Club.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF53F621FF5329D00E12D4F /* Club.swift */; };
 		1FF53F681FF5329D00E12D4F /* Club.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF53F621FF5329D00E12D4F /* Club.swift */; };
 		1FF53F691FF5329D00E12D4F /* Club.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF53F621FF5329D00E12D4F /* Club.swift */; };
@@ -162,6 +186,13 @@
 		1F52BD5E2038E23700F00ADC /* athlete_stats_200.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = athlete_stats_200.json; sourceTree = "<group>"; };
 		1F5CBB3C203D643700625DBF /* AthleteStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AthleteStats.swift; sourceTree = "<group>"; };
 		1F5EA43F1FF51BA200ED872E /* StravaAPIClient.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = StravaAPIClient.podspec; sourceTree = "<group>"; };
+		1F5F5718204DD15700EA471F /* error_notfound_404.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = error_notfound_404.json; sourceTree = "<group>"; };
+		1F5F571C204DEC4000EA471F /* error_rate_limit_403.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = error_rate_limit_403.json; sourceTree = "<group>"; };
+		1F5F5721204DF00800EA471F /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
+		1F5F5726204DF6CA00EA471F /* HTTPURLResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPURLResponse.swift; sourceTree = "<group>"; };
+		1F5F572B204DF92100EA471F /* error_unauthorized_401.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = error_unauthorized_401.json; sourceTree = "<group>"; };
+		1F5F572F204DFC1800EA471F /* current_athlete_200_invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = current_athlete_200_invalid.json; sourceTree = "<group>"; };
+		1FB22C07204AA29C00727745 /* APIErrorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIErrorModel.swift; sourceTree = "<group>"; };
 		1FF53F5B1FF531B200E12D4F /* swiftlint.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = swiftlint.sh; path = scripts/swiftlint.sh; sourceTree = "<group>"; };
 		1FF53F5C1FF531BB00E12D4F /* Gemfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile; sourceTree = "<group>"; };
 		1FF53F5D1FF531C400E12D4F /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -288,7 +319,11 @@
 			children = (
 				1F52BD4E2038BA1C00F00ADC /* athlete_activities_200.json */,
 				1F52BD5E2038E23700F00ADC /* athlete_stats_200.json */,
+				1F5F572F204DFC1800EA471F /* current_athlete_200_invalid.json */,
 				1F52BD562038BC9400F00ADC /* current_athlete_200.json */,
+				1F5F5718204DD15700EA471F /* error_notfound_404.json */,
+				1F5F571C204DEC4000EA471F /* error_rate_limit_403.json */,
+				1F5F572B204DF92100EA471F /* error_unauthorized_401.json */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -310,6 +345,14 @@
 			name = "Podspec Metadata";
 			sourceTree = "<group>";
 		};
+		1F5F5720204DEFF300EA471F /* Errors */ = {
+			isa = PBXGroup;
+			children = (
+				1F5F5721204DF00800EA471F /* Errors.swift */,
+			);
+			path = Errors;
+			sourceTree = "<group>";
+		};
 		1FF53F611FF5329D00E12D4F /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -325,6 +368,7 @@
 				1F52BD432038A65D00F00ADC /* Photo.swift */,
 				1F52BD482038A77200F00ADC /* SplitsMetric.swift */,
 				1F5CBB3C203D643700625DBF /* AthleteStats.swift */,
+				1FB22C07204AA29C00727745 /* APIErrorModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -332,6 +376,7 @@
 		1FF53F651FF5329D00E12D4F /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				1F5F5726204DF6CA00EA471F /* HTTPURLResponse.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -339,6 +384,7 @@
 		1FF53F661FF5329D00E12D4F /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				1F5F5720204DEFF300EA471F /* Errors */,
 				1FF53F841FF54A0100E12D4F /* Resources */,
 				1FF53F731FF5400600E12D4F /* Enums */,
 				1FF53F791FF5477200E12D4F /* HTTPRequester.swift */,
@@ -751,9 +797,13 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F5F571D204DEC4000EA471F /* error_rate_limit_403.json in Resources */,
+				1F5F5719204DD15700EA471F /* error_notfound_404.json in Resources */,
 				1F52BD572038BC9400F00ADC /* current_athlete_200.json in Resources */,
 				1F52BD5F2038E23700F00ADC /* athlete_stats_200.json in Resources */,
+				1F5F572C204DF92100EA471F /* error_unauthorized_401.json in Resources */,
 				1F52BD4F2038BA1C00F00ADC /* athlete_activities_200.json in Resources */,
+				1F5F5730204DFC1800EA471F /* current_athlete_200_invalid.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -782,9 +832,13 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F5F571E204DEC4000EA471F /* error_rate_limit_403.json in Resources */,
+				1F5F571A204DD15700EA471F /* error_notfound_404.json in Resources */,
 				1F52BD582038BC9400F00ADC /* current_athlete_200.json in Resources */,
 				1F52BD602038E23700F00ADC /* athlete_stats_200.json in Resources */,
+				1F5F572D204DF92100EA471F /* error_unauthorized_401.json in Resources */,
 				1F52BD502038BA1C00F00ADC /* athlete_activities_200.json in Resources */,
+				1F5F5731204DFC1800EA471F /* current_athlete_200_invalid.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -792,9 +846,13 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F5F571F204DEC4000EA471F /* error_rate_limit_403.json in Resources */,
+				1F5F571B204DD15700EA471F /* error_notfound_404.json in Resources */,
 				1F52BD592038BC9400F00ADC /* current_athlete_200.json in Resources */,
 				1F52BD612038E23700F00ADC /* athlete_stats_200.json in Resources */,
+				1F5F572E204DF92100EA471F /* error_unauthorized_401.json in Resources */,
 				1F52BD512038BA1C00F00ADC /* athlete_activities_200.json in Resources */,
+				1F5F5732204DFC1800EA471F /* current_athlete_200_invalid.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1117,6 +1175,7 @@
 				1F52BD3A2038A64200F00ADC /* Segment.swift in Sources */,
 				1F52BD492038A77200F00ADC /* SplitsMetric.swift in Sources */,
 				1F5CBB3D203D643700625DBF /* AthleteStats.swift in Sources */,
+				1F5F5727204DF6CA00EA471F /* HTTPURLResponse.swift in Sources */,
 				1F52BD3F2038A65000F00ADC /* Map.swift in Sources */,
 				1FF53F801FF5487E00E12D4F /* URLResourceRequestConvertible.swift in Sources */,
 				1FF53F671FF5329D00E12D4F /* Club.swift in Sources */,
@@ -1125,7 +1184,9 @@
 				1FF53F901FF5A78700E12D4F /* RequestSerializer.swift in Sources */,
 				1F52BD302038A61900F00ADC /* HighlightedKudoser.swift in Sources */,
 				1FF53F861FF54A0E00E12D4F /* StravaAPIRouter.swift in Sources */,
+				1F5F5722204DF00800EA471F /* Errors.swift in Sources */,
 				1FF53F6B1FF5329D00E12D4F /* Bike.swift in Sources */,
+				1FB22C08204AA29C00727745 /* APIErrorModel.swift in Sources */,
 				1F52BD2B2038A60900F00ADC /* Gear.swift in Sources */,
 				1F52BD442038A65D00F00ADC /* Photo.swift in Sources */,
 				1FF53F751FF5401800E12D4F /* HTTPMethod.swift in Sources */,
@@ -1153,6 +1214,7 @@
 				1F52BD3C2038A64200F00ADC /* Segment.swift in Sources */,
 				1F52BD4B2038A77200F00ADC /* SplitsMetric.swift in Sources */,
 				1F5CBB3F203D643700625DBF /* AthleteStats.swift in Sources */,
+				1F5F5729204DF6CA00EA471F /* HTTPURLResponse.swift in Sources */,
 				1F52BD412038A65000F00ADC /* Map.swift in Sources */,
 				1FF53F821FF5487E00E12D4F /* URLResourceRequestConvertible.swift in Sources */,
 				1FF53F691FF5329D00E12D4F /* Club.swift in Sources */,
@@ -1161,7 +1223,9 @@
 				1FF53F921FF5A78700E12D4F /* RequestSerializer.swift in Sources */,
 				1F52BD322038A61900F00ADC /* HighlightedKudoser.swift in Sources */,
 				1FF53F881FF54A0E00E12D4F /* StravaAPIRouter.swift in Sources */,
+				1F5F5724204DF00800EA471F /* Errors.swift in Sources */,
 				1FF53F6D1FF5329D00E12D4F /* Bike.swift in Sources */,
+				1FB22C0A204AA29C00727745 /* APIErrorModel.swift in Sources */,
 				1F52BD2D2038A60900F00ADC /* Gear.swift in Sources */,
 				1F52BD462038A65D00F00ADC /* Photo.swift in Sources */,
 				1FF53F771FF5401800E12D4F /* HTTPMethod.swift in Sources */,
@@ -1179,6 +1243,7 @@
 				1F52BD3D2038A64200F00ADC /* Segment.swift in Sources */,
 				1F52BD4C2038A77200F00ADC /* SplitsMetric.swift in Sources */,
 				1F5CBB40203D643700625DBF /* AthleteStats.swift in Sources */,
+				1F5F572A204DF6CA00EA471F /* HTTPURLResponse.swift in Sources */,
 				1F52BD422038A65000F00ADC /* Map.swift in Sources */,
 				1FF53F831FF5487E00E12D4F /* URLResourceRequestConvertible.swift in Sources */,
 				1FF53F6A1FF5329D00E12D4F /* Club.swift in Sources */,
@@ -1187,7 +1252,9 @@
 				1FF53F931FF5A78700E12D4F /* RequestSerializer.swift in Sources */,
 				1F52BD332038A61900F00ADC /* HighlightedKudoser.swift in Sources */,
 				1FF53F891FF54A0E00E12D4F /* StravaAPIRouter.swift in Sources */,
+				1F5F5725204DF00800EA471F /* Errors.swift in Sources */,
 				1FF53F6E1FF5329D00E12D4F /* Bike.swift in Sources */,
+				1FB22C0B204AA29C00727745 /* APIErrorModel.swift in Sources */,
 				1F52BD2E2038A60900F00ADC /* Gear.swift in Sources */,
 				1F52BD472038A65D00F00ADC /* Photo.swift in Sources */,
 				1FF53F781FF5401800E12D4F /* HTTPMethod.swift in Sources */,
@@ -1205,6 +1272,7 @@
 				1F52BD3B2038A64200F00ADC /* Segment.swift in Sources */,
 				1F52BD4A2038A77200F00ADC /* SplitsMetric.swift in Sources */,
 				1F5CBB3E203D643700625DBF /* AthleteStats.swift in Sources */,
+				1F5F5728204DF6CA00EA471F /* HTTPURLResponse.swift in Sources */,
 				1F52BD402038A65000F00ADC /* Map.swift in Sources */,
 				1FF53F811FF5487E00E12D4F /* URLResourceRequestConvertible.swift in Sources */,
 				1FF53F681FF5329D00E12D4F /* Club.swift in Sources */,
@@ -1213,7 +1281,9 @@
 				1FF53F911FF5A78700E12D4F /* RequestSerializer.swift in Sources */,
 				1F52BD312038A61900F00ADC /* HighlightedKudoser.swift in Sources */,
 				1FF53F871FF54A0E00E12D4F /* StravaAPIRouter.swift in Sources */,
+				1F5F5723204DF00800EA471F /* Errors.swift in Sources */,
 				1FF53F6C1FF5329D00E12D4F /* Bike.swift in Sources */,
+				1FB22C09204AA29C00727745 /* APIErrorModel.swift in Sources */,
 				1F52BD2C2038A60900F00ADC /* Gear.swift in Sources */,
 				1F52BD452038A65D00F00ADC /* Photo.swift in Sources */,
 				1FF53F761FF5401800E12D4F /* HTTPMethod.swift in Sources */,

--- a/Tests/StravaAPIClientTests/Mocks/current_athlete_200_invalid.json
+++ b/Tests/StravaAPIClientTests/Mocks/current_athlete_200_invalid.json
@@ -1,0 +1,111 @@
+{
+    "id": 3246330,
+    "uzername": null,
+    "rezource_state": 3,
+    "fihrstname": "Carlos",
+    "lastname": "Ricardo",
+    "cyti": "Porto",
+    "state": "Porto District",
+    "country": "Portugal",
+    "sex": "M",
+    "premium": false,
+    "created_at": "2014-03-23T14:56:03Z",
+    "updated_at": "2017-12-26T20:47:48Z",
+    "badge_type_id": 0,
+    "profile_medium": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/4246969/1483887/3/medium.jpg",
+    "profile": "https://dgalywyr863hv.cloudfront.net/pictures/athletes/4246969/1483887/3/large.jpg",
+    "friend": null,
+    "follower": null,
+    "email": "carlosricardosantos@gmail.com",
+    "follower_count": 128,
+    "friend_count": 219,
+    "mutual_friend_count": 0,
+    "athlete_type": 1,
+    "date_preference": "%m/%d/%Y",
+    "measurement_preference": "meters",
+    "clubs": [
+        {
+            "id": 53850,
+            "resource_state": 2,
+            "name": "ASICS Run Club",
+            "profile_medium": "https://dgalywyr863hv.cloudfront.net/pictures/clubs/53850/1275851/1/medium.jpg",
+            "profile": "https://dgalywyr863hv.cloudfront.net/pictures/clubs/53850/1275851/1/large.jpg",
+            "cover_photo": null,
+            "cover_photo_small": null,
+            "sport_type": "running",
+            "city": "Irvine",
+            "state": "California",
+            "country": "United States",
+            "private": false,
+            "member_count": 5295,
+            "featured": false,
+            "verified": false,
+            "url": "ASICSAmerica",
+            "membership": "member",
+            "admin": false,
+            "owner": false
+        },
+        {
+            "id": 255775,
+            "resource_state": 2,
+            "name": "Garmin Forerunners",
+            "profile_medium": "https://dgalywyr863hv.cloudfront.net/pictures/clubs/255775/5639309/5/medium.jpg",
+            "profile": "https://dgalywyr863hv.cloudfront.net/pictures/clubs/255775/5639309/5/large.jpg",
+            "cover_photo": "https://dgalywyr863hv.cloudfront.net/pictures/clubs/255775/5639291/1/large.jpg",
+            "cover_photo_small": "https://dgalywyr863hv.cloudfront.net/pictures/clubs/255775/5639291/1/small.jpg",
+            "sport_type": "running",
+            "city": "Olathe",
+            "state": "Kansas",
+            "country": "United States",
+            "private": false,
+            "member_count": 19692,
+            "featured": false,
+            "verified": true,
+            "url": "garminforerunner",
+            "membership": "member",
+            "admin": false,
+            "owner": false
+        }
+    ],
+    "ftp": null,
+    "weight": 75.5,
+    "bikes": [
+        {
+            "id": "b1277412",
+            "primary": true,
+            "name": "Scott Scale 950 (2013)",
+            "resource_state": 2,
+            "distance": 346329
+        }
+    ],
+    "shoes": [
+        {
+            "id": "g1915196",
+            "primary": false,
+            "name": "ASICS Nimbus 18",
+            "resource_state": 2,
+            "distance": 524532
+        },
+        {
+            "id": "g2331015",
+            "primary": false,
+            "name": "ASICS Gel Venture - 5",
+            "resource_state": 2,
+            "distance": 67385
+        },
+        {
+            "id": "g2519870",
+            "primary": true,
+            "name": "adidas UltraBoost Adidas Ultraboost",
+            "resource_state": 2,
+            "distance": 481184
+        },
+        {
+            "id": "g2896361",
+            "primary": false,
+            "name": "La Sportiva Bushido Bushido",
+            "resource_state": 2,
+            "distance": 71104
+        }
+    ]
+}

--- a/Tests/StravaAPIClientTests/Mocks/error_notfound_404.json
+++ b/Tests/StravaAPIClientTests/Mocks/error_notfound_404.json
@@ -1,0 +1,10 @@
+{
+    "message": "Record Not Found",
+    "errors": [
+        {
+            "resource": "resource",
+            "field": "path",
+            "code": "invalid"
+        }
+    ]
+}

--- a/Tests/StravaAPIClientTests/Mocks/error_rate_limit_403.json
+++ b/Tests/StravaAPIClientTests/Mocks/error_rate_limit_403.json
@@ -1,0 +1,10 @@
+{
+    "message": "Rate Limit Exceeded",
+    "errors": [
+        {
+            "resource": "Application",
+            "field": "rate limit",
+            "code": "exceeded"
+        }
+    ]
+}

--- a/Tests/StravaAPIClientTests/Mocks/error_unauthorized_401.json
+++ b/Tests/StravaAPIClientTests/Mocks/error_unauthorized_401.json
@@ -1,0 +1,4 @@
+{
+    "message": "Authorization Error",
+    "errors": []
+}

--- a/Tests/StravaAPIClientTests/StravaAPIClientIntegrationTests.swift
+++ b/Tests/StravaAPIClientTests/StravaAPIClientIntegrationTests.swift
@@ -41,12 +41,12 @@ class StravaAPIClientIntegrationTests: XCTestCase {
             if case let .success(athlete) = result {
 
                 debugPrint("Got Athlete: \(athlete)")
+                expectation.fulfill()
 
             } else if case let .failure(error) = result {
 
-                debugPrint("Error: \(error)")
+                XCTFail("Error: \(error)")
             }
-            expectation.fulfill()
         }
     }
 
@@ -58,12 +58,12 @@ class StravaAPIClientIntegrationTests: XCTestCase {
             if case let .success(activities) = result {
 
                 debugPrint("Got Activities: \(activities)")
+                expectation.fulfill()
 
             } else if case let .failure(error) = result {
 
-                debugPrint("Error: \(error)")
+                XCTFail("Error: \(error)")
             }
-            expectation.fulfill()
         }
         self.wait(for: [expectation], timeout: 2.0)
     }
@@ -76,12 +76,12 @@ class StravaAPIClientIntegrationTests: XCTestCase {
             if case let .success(stats) = result {
 
                 debugPrint("Got Stats: \(stats)")
+                expectation.fulfill()
 
             } else if case let .failure(error) = result {
 
-                debugPrint("Error: \(error)")
+                XCTFail("Error: \(error)")
             }
-            expectation.fulfill()
         }
         self.wait(for: [expectation], timeout: 2.0)
     }

--- a/Tests/StravaAPIClientTests/StravaAPIClientMockTests.swift
+++ b/Tests/StravaAPIClientTests/StravaAPIClientMockTests.swift
@@ -130,7 +130,7 @@ class StravaAPIClientMockTests: XCTestCase {
 
             if case let .failure(error) = result,
                 case let .apiError(apiError, errorModel) = error,
-                case .unknown = apiError,
+                case .forbidden = apiError,
                 errorModel.errors.count == 1 {
 
                 expectation.fulfill()

--- a/Tests/StravaAPIClientTests/StravaAPIClientMockTests.swift
+++ b/Tests/StravaAPIClientTests/StravaAPIClientMockTests.swift
@@ -41,6 +41,176 @@ class StravaAPIClientMockTests: XCTestCase {
         super.tearDown()
         self.removeAllStubs()
     }
+
+    // MARK: Errors
+
+    func testInvalidJSONResponse() {
+
+        let stub = self.mock(uri: "\(Constants.apiPrefix)/athlete", jsonFilename: "current_athlete_200_invalid")
+        let expectation = XCTestExpectation(description: "requestCurrentAthlete")
+        self.client.requestCurrentAthlete { result in
+
+            if case let .failure(error) = result,
+                case let .parsingError(parseError) = error,
+                case let .decode(decodingError) = parseError,
+                let decodedError = (decodingError as? DecodingError),
+                case let DecodingError.keyNotFound(codingKey, _) = decodedError {
+
+                XCTAssertEqual(codingKey.stringValue, "resource_state")
+                expectation.fulfill()
+
+            } else if case let .failure(error) = result {
+
+                XCTFail("Error: \(error)")
+            }
+        }
+        self.wait(for: [expectation], timeout: 1.0)
+        self.removeStub(stub)
+    }
+
+    func testError404NotFound() {
+
+        let stub = self.mockServerErrorData(uri: "\(Constants.apiPrefix)/athlete", jsonFilename: "error_notfound_404", status: 404)
+        let expectation = XCTestExpectation(description: "requestCurrentAthleteError404")
+        self.client.requestCurrentAthlete { result in
+
+            if case let .failure(error) = result,
+                case let .apiError(apiError, errorModel) = error,
+                case .notFound = apiError,
+                errorModel.errors.count == 1 {
+
+                expectation.fulfill()
+
+            } else {
+
+                XCTFail("Result: \(result)")
+            }
+        }
+        self.wait(for: [expectation], timeout: 1.0)
+        self.removeStub(stub)
+    }
+
+    func testError403RateLimit() {
+
+        let headers = [
+            "X-RateLimit-Limit": "600,30000",
+            "X-RateLimit-Usage": "642,27300"
+        ]
+        let stub = self.mockServerErrorData(uri: "\(Constants.apiPrefix)/athlete", jsonFilename: "error_rate_limit_403", status: 403, headers: headers)
+        let expectation = XCTestExpectation(description: "requestCurrentAthleteError403RateLimit")
+        self.client.requestCurrentAthlete { result in
+
+            if case let .failure(error) = result,
+                case let .apiError(apiError, errorModel) = error,
+                case let .rateLimitingExceeded(limit, usage) = apiError,
+                usage.shortTerm == 642,
+                limit.longTerm == 30000,
+                errorModel.errors.count == 1 {
+
+                expectation.fulfill()
+
+            } else {
+
+                XCTFail("Result: \(result)")
+            }
+        }
+        self.wait(for: [expectation], timeout: 1.0)
+        self.removeStub(stub)
+    }
+
+    func testError403InvalidRateLimit() {
+
+        let headers = [
+            "X-RateLimit-Limit": "30000",
+            "X-RateLimit-Usage": "642"
+        ]
+        let stub = self.mockServerErrorData(uri: "\(Constants.apiPrefix)/athlete", jsonFilename: "error_rate_limit_403", status: 403, headers: headers)
+        let expectation = XCTestExpectation(description: "requestCurrentAthleteError403InvalidRateLimit")
+        self.client.requestCurrentAthlete { result in
+
+            if case let .failure(error) = result,
+                case let .apiError(apiError, errorModel) = error,
+                case .unknown = apiError,
+                errorModel.errors.count == 1 {
+
+                expectation.fulfill()
+
+            } else {
+
+                XCTFail("Result: \(result)")
+            }
+        }
+        self.wait(for: [expectation], timeout: 1.0)
+        self.removeStub(stub)
+    }
+
+    func testError403Forbidden() {
+
+        let stub = self.mockServerErrorData(uri: "\(Constants.apiPrefix)/athlete", jsonFilename: "error_rate_limit_403", status: 403)
+        let expectation = XCTestExpectation(description: "requestCurrentAthleteError403Forbidden")
+        self.client.requestCurrentAthlete { result in
+
+            if case let .failure(error) = result,
+                case let .apiError(apiError, errorModel) = error,
+                case .forbidden = apiError,
+                errorModel.errors.count == 1 {
+
+                expectation.fulfill()
+
+            } else {
+
+                XCTFail("Result: \(result)")
+            }
+        }
+        self.wait(for: [expectation], timeout: 1.0)
+        self.removeStub(stub)
+    }
+
+    func testError401Unauthorized() {
+
+        let stub = self.mockServerErrorData(uri: "\(Constants.apiPrefix)/athlete", jsonFilename: "error_unauthorized_401", status: 401)
+        let expectation = XCTestExpectation(description: "requestCurrentAthleteError401")
+        self.client.requestCurrentAthlete { result in
+
+            if case let .failure(error) = result,
+                case let .apiError(apiError, errorModel) = error,
+                case .unauthorized = apiError,
+                errorModel.errors.count == 0 {
+
+                expectation.fulfill()
+
+            } else {
+
+                XCTFail("Result: \(result)")
+            }
+        }
+        self.wait(for: [expectation], timeout: 1.0)
+        self.removeStub(stub)
+    }
+
+    func testError500() {
+
+        let stub = self.mockServerErrorData(uri: "\(Constants.apiPrefix)/athlete", jsonFilename: "error_unauthorized_401", status: 500)
+        let expectation = XCTestExpectation(description: "requestCurrentAthleteError500")
+        self.client.requestCurrentAthlete { result in
+
+            if case let .failure(error) = result,
+                case let .apiError(apiError, errorModel) = error,
+                case .unknown = apiError,
+                errorModel.errors.count == 0 {
+
+                expectation.fulfill()
+
+            } else {
+
+                XCTFail("Result: \(result)")
+            }
+        }
+        self.wait(for: [expectation], timeout: 1.0)
+        self.removeStub(stub)
+    }
+
+    // MARK: Resources
     
     func testMockCurrentLoggedInAthleteOk() {
         
@@ -58,7 +228,7 @@ class StravaAPIClientMockTests: XCTestCase {
                 XCTFail("Error: \(error)")
             }
         }
-        self.wait(for: [expectation], timeout: 2.0)
+        self.wait(for: [expectation], timeout: 1.0)
         self.removeStub(stub)
     }
     
@@ -82,7 +252,7 @@ class StravaAPIClientMockTests: XCTestCase {
             }
         }
         
-        self.wait(for: [expectation], timeout: 2.0)
+        self.wait(for: [expectation], timeout: 1.0)
         self.removeStub(errorStub)
     }
     
@@ -104,7 +274,7 @@ class StravaAPIClientMockTests: XCTestCase {
             }
         }
         
-        self.wait(for: [expectation], timeout: 2.0)
+        self.wait(for: [expectation], timeout: 1.0)
         self.removeStub(errorStub)
     }
     
@@ -126,27 +296,8 @@ class StravaAPIClientMockTests: XCTestCase {
                 XCTFail("Error: \(error)")
             }
         }
-        self.wait(for: [expectation], timeout: 2.0)
+        self.wait(for: [expectation], timeout: 1.0)
         self.removeStub(stub)
-    }
-    
-    func testCurrentAthleteActivitiesError() {
-        
-        let errorStub = self.mockServerError(path: "\(Constants.apiPrefix)/athlete/activities")
-        let errorExpectation = XCTestExpectation(description: "errorRequestCurrentAthleteActivities")
-        self.client.requestCurrentAthleteActivities { result in
-            
-            if case .failure = result {
-                
-                errorExpectation.fulfill()
-                
-            } else{
-                
-                XCTFail()
-            }
-        }
-        self.wait(for: [errorExpectation], timeout: 2.0)
-        self.removeStub(errorStub)
     }
     
     func testCurrentAthleteStatsOk() {
@@ -169,26 +320,7 @@ class StravaAPIClientMockTests: XCTestCase {
                 XCTFail("Error: \(error)")
             }
         }
-        self.wait(for: [expectation], timeout: 2.0)
+        self.wait(for: [expectation], timeout: 1.0)
         self.removeStub(stub)
-    }
-    
-    func testCurrentAthleteStatsError() {
-        
-        let errorStub = self.mockServerError(path: "\(Constants.apiPrefix)/athletes/1234/stats")
-        let errorExpectation = XCTestExpectation(description: "errorRequestCurrentAthleteStats")
-        self.client.requestCurrentAthleteStats(athleteId: 1234) { result in
-            
-            if case .failure = result {
-                
-                errorExpectation.fulfill()
-                
-            } else{
-                
-                XCTFail()
-            }
-        }
-        self.wait(for: [errorExpectation], timeout: 2.0)
-        self.removeStub(errorStub)
     }
 }

--- a/Tests/StravaAPIClientTests/XCTestCase+Load.swift
+++ b/Tests/StravaAPIClientTests/XCTestCase+Load.swift
@@ -15,7 +15,7 @@ extension XCTestCase {
     @discardableResult
     func mock(uri: String, verb: HTTPMethod = .get, jsonFilename: String) -> Stub {
 
-        let path = Bundle(for: type(of: self)).path(forResource:jsonFilename, ofType: "json")!
+        let path = Bundle(for: type(of: self)).path(forResource: jsonFilename, ofType: "json")!
         let data = try! Data(contentsOf: URL(fileURLWithPath: path))
         return stub(http(verb, uri: uri), jsonData(data))
     }
@@ -24,6 +24,14 @@ extension XCTestCase {
     func mockServerEmptyData(path: String, verb: HTTPMethod = .get) -> Stub {
 
         return stub(http(verb, uri: path), http(500))
+    }
+
+    @discardableResult
+    func mockServerErrorData(uri: String, verb: HTTPMethod = .get, jsonFilename: String, status: Int = 400, headers: [String:String]? = nil) -> Stub {
+
+        let path = Bundle(for: type(of: self)).path(forResource: jsonFilename, ofType: "json")!
+        let data = try! Data(contentsOf: URL(fileURLWithPath: path))
+        return stub(http(verb, uri: uri), jsonData(data, status: status, headers: headers))
     }
 
     @discardableResult


### PR DESCRIPTION
# What?

* Improving error handling on Networking
  * includes new tests to 404  and 403 (forbidden, rate limiting, etc)

# TODO

`ParseError`'s `case decode(Error)` could be a `DecodingError`, but how? I can't `catch` a typed error to pass to another function.